### PR TITLE
feat: support instabug flutter sdk v12 and v13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Add support for Instabug Flutter SDK v12 ([#17](https://github.com/Instabug/Instabug-Dart-http-Adapter/pull/17)).
+- Add support for Instabug Flutter SDK v12 and v13 ([#17](https://github.com/Instabug/Instabug-Dart-http-Adapter/pull/17)).
 
 ## [2.3.0] - 3/11/2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Changelog
+
+## Unreleased
+
+### Added
+
+- Add support for Instabug Flutter SDK v12 ([#17](https://github.com/Instabug/Instabug-Dart-http-Adapter/pull/17)).
+
 ## [2.3.0] - 3/11/2022
 
 - Adds support for MultipartRequest.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -28,10 +28,6 @@ analyzer:
     missing_return: warning
     # allow having TODOs in the code
     todo: ignore
-    # Ignore analyzer hints for updating pubspecs when using Future or
-    # Stream and not importing dart:async
-    # Please see https://github.com/flutter/flutter/pull/24528 for details.
-    sdk_version_async_exported_from_core: ignore
   exclude:
     - 'bin/cache/**'
     # the following two are relative to the stocks example and the flutter package respectively

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -4,11 +4,10 @@ import 'package:instabug_flutter/instabug_flutter.dart';
 
 Future<void> main() async {
   runApp(const MyApp());
-  Instabug.start(
-      'ed6f659591566da19b67857e1b9d40ab', [InvocationEvent.floatingButton]);
+  Instabug.init(
+     token:  'ed6f659591566da19b67857e1b9d40ab', invocationEvents: [InvocationEvent.floatingButton]);
   final client = InstabugHttpClient();
-  final response = await client.get(Uri.parse('https://google.com'));
-  print(response.body);
+  await client.get(Uri.parse('https://google.com'));
 }
 
 class MyApp extends StatelessWidget {
@@ -58,7 +57,7 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
             Text(
               '$_counter',
-              style: Theme.of(context).textTheme.headline4,
+              style: Theme.of(context).textTheme.headlineMedium,
             ),
           ],
         ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^0.13.3
-  instabug_flutter: '>=11.0.0 <12.0.0'
+  instabug_flutter: '>=11.0.0 <13.0.0'
   meta: ^1.3.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: ^0.13.3
-  instabug_flutter: '>=11.0.0 <13.0.0'
+  instabug_flutter: '>=11.0.0 <14.0.0'
   meta: ^1.3.0
 
 dev_dependencies:

--- a/test/instabug_http_client_test.dart
+++ b/test/instabug_http_client_test.dart
@@ -14,7 +14,7 @@ import 'package:mockito/mockito.dart';
 
 import 'instabug_http_client_test.mocks.dart';
 
-@GenerateMocks([
+@GenerateMocks(<Type>[
   InstabugHttpLogger,
   InstabugHttpClient,
 ])


### PR DESCRIPTION
## Description of the change

Relax the `instabug_flutter` dependency constraints to contain version v12 and v13.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## Related issues

Jira ID: MOB-13752

## Checklists
### Development
- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
### Code review 
- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request 
